### PR TITLE
Fixes #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ The history will also be stored between sessions.
 
 The default result styles are copied from Atom's find-and-replace package so it will look
 familiar, but it uses custom classes which you can style.  To style the current result use
-`.editor .isearch-current .region`.  To style other results `.editor .isearch-result .region`.
+`atom-text-editor::shadow .isearch-current .region`.  To style other results
+`atom-text-editor::shadow .isearch-result .region`.
 
 For example, to change the border around the current search result to red, you would add
 the following to your ~/.atom/styles.less file:
 
 ```css
-.editor .isearch-current .region {
+atom-text-editor::shadow .isearch-current .region {
   border: 1px solid red;
 }
 ```

--- a/stylesheets/isearch.less
+++ b/stylesheets/isearch.less
@@ -25,12 +25,14 @@
 // I'm defaulting to the same values that the find-and-replace package is using since they are
 // the same concept.  I want this package to work seamlessly with that one.
 
+atom-text-editor::shadow .isearch-result .region,
 .editor .isearch-result .region {
   background-color: transparent;
   border-radius: @component-border-radius;
   border: 1px solid @syntax-result-marker-color;
 }
 
+atom-text-editor::shadow .isearch-current .region,
 .editor .isearch-current .region {
   background-color: transparent;
   border-radius: @component-border-radius;


### PR DESCRIPTION
Fixes #22, "Found word is not getting highlighted with Shadow Dom enabled"

Starting with Atom 0.166.0 - released yesterday - the Shadow DOM is enabled by default.

The stylesheet changes were made based on this guide:

  https://github.com/atom/atom/blob/master/docs/upgrading/upgrading-your-ui-theme.md